### PR TITLE
incluida página Login como página principal

### DIFF
--- a/src/components/system/routes.js
+++ b/src/components/system/routes.js
@@ -26,6 +26,7 @@ function Routes() {
   return (
     <Router>
       <Switch>
+        <PublicRoute path="/" component={Login} exact />
         <PublicRoute path={appRoutes.login} component={Login} exact />
         <PublicRoute path={appRoutes.register} component={Register} exact />
         <PrivateRoute path={appRoutes.meProfile} component={MeProfile} exact />


### PR DESCRIPTION
He actualizado las rutas haciendo que la ruta que va a la página principal del proyecto sea directamente el login, y si incluyes /login en el navegador sea también el login